### PR TITLE
Fix error translation loaded too early

### DIFF
--- a/src/Beta.php
+++ b/src/Beta.php
@@ -55,10 +55,10 @@ class Beta {
 	 * @param string $version     The current version of the plugin.
 	 */
 	public function __construct( Optin $optin, string $file, string $plugin_slug, string $version ) {
-		$this->optin          = $optin;
-		self::$file           = $file;
-		$this->plugin_slug    = $plugin_slug;
-		$this->version        = $version;
+		$this->optin       = $optin;
+		self::$file        = $file;
+		$this->plugin_slug = $plugin_slug;
+		$this->version     = $version;
 	}
 
 	/**

--- a/src/Beta.php
+++ b/src/Beta.php
@@ -44,23 +44,21 @@ class Beta {
 	 *
 	 * @var string
 	 */
-	private $update_message;
+	private $update_message = 'This update will install a beta version of the plugin.';
 
 	/**
 	 * Constructor.
 	 *
-	 * @param Optin  $optin          The opt-in instance.
-	 * @param string $file           The plugin file.
-	 * @param string $plugin_slug    The plugin slug.
-	 * @param string $version        The current version of the plugin.
-	 * @param string $update_message The update message.
+	 * @param Optin  $optin       The opt-in instance.
+	 * @param string $file        The plugin file.
+	 * @param string $plugin_slug The plugin slug.
+	 * @param string $version     The current version of the plugin.
 	 */
-	public function __construct( Optin $optin, string $file, string $plugin_slug, string $version, string $update_message ) {
+	public function __construct( Optin $optin, string $file, string $plugin_slug, string $version ) {
 		$this->optin          = $optin;
 		self::$file           = $file;
 		$this->plugin_slug    = $plugin_slug;
 		$this->version        = $version;
-		$this->update_message = $update_message;
 	}
 
 	/**
@@ -71,6 +69,17 @@ class Beta {
 	public function init(): void {
 		add_filter( 'site_transient_update_plugins', [ $this, 'transient_update_plugins' ] );
 		add_action( 'in_plugin_update_message-' . self::$file, [ $this, 'plugin_update_message' ] );
+	}
+
+	/**
+	 * Sets the update message.
+	 *
+	 * @param string $message The update message.
+	 *
+	 * @return void
+	 */
+	public function set_update_message( string $message ): void {
+		$this->update_message = $message;
 	}
 
 	/**

--- a/tests/Fixtures/Beta/TransientUpdatePluginsTest.php
+++ b/tests/Fixtures/Beta/TransientUpdatePluginsTest.php
@@ -26,7 +26,7 @@ $beta_transient = (object) [
 			],
 			'banners_rtl'    => [],
 			'is_beta'        => true,
-			'upgrade_notice' => 'This is a beta update message.',
+			'upgrade_notice' => 'This update will install a beta version of the plugin.',
 		],
 	],
 	'no_update' => [],

--- a/tests/Integration/Beta/PluginUpdateMessageTest.php
+++ b/tests/Integration/Beta/PluginUpdateMessageTest.php
@@ -83,6 +83,6 @@ class PluginUpdateMessageTest extends TestCase {
 			return;
 		}
 
-		$this->expectOutputContains( 'This is a beta update message.' );
+		$this->expectOutputContains( 'This update will install a beta version of the plugin.' );
 	}
 }

--- a/tests/Integration/Beta/PluginUpdateMessageTest.php
+++ b/tests/Integration/Beta/PluginUpdateMessageTest.php
@@ -40,8 +40,7 @@ class PluginUpdateMessageTest extends TestCase {
 			$this->optin,
 			'test-plugin/test-plugin.php',
 			'test_plugin',
-			'1.0.0',
-			'This is a beta update message.'
+			'1.0.0'
 		);
 	}
 

--- a/tests/Integration/Beta/TransientUpdatePluginsTest.php
+++ b/tests/Integration/Beta/TransientUpdatePluginsTest.php
@@ -39,8 +39,7 @@ class TransientUpdatePluginsTest extends TestCase {
 			$this->optin,
 			'test-plugin/test-plugin.php',
 			'test_plugin',
-			'1.0.0',
-			'This is a beta update message.'
+			'1.0.0'
 		);
 	}
 

--- a/tests/Unit/Beta/PluginUpdateMessageTest.php
+++ b/tests/Unit/Beta/PluginUpdateMessageTest.php
@@ -43,8 +43,7 @@ class PluginUpdateMessageTest extends TestCase {
 			$this->optin,
 			'test-plugin/test-plugin.php',
 			'test_plugin',
-			'1.0.0',
-			'This is a beta update message.'
+			'1.0.0'
 		);
 	}
 

--- a/tests/Unit/Beta/PluginUpdateMessageTest.php
+++ b/tests/Unit/Beta/PluginUpdateMessageTest.php
@@ -69,6 +69,6 @@ class PluginUpdateMessageTest extends TestCase {
 			return;
 		}
 
-		$this->expectOutputContains( 'This is a beta update message.' );
+		$this->expectOutputContains( 'This update will install a beta version of the plugin.' );
 	}
 }

--- a/tests/Unit/Beta/TransientUpdatePluginsTest.php
+++ b/tests/Unit/Beta/TransientUpdatePluginsTest.php
@@ -44,8 +44,7 @@ class TransientUpdatePluginsTest extends TestCase {
 			$this->optin,
 			'test-plugin/test-plugin.php',
 			'test_plugin',
-			'1.0.0',
-			'This is a beta update message.'
+			'1.0.0'
 		);
 	}
 


### PR DESCRIPTION
# Description

Passing the update message as a parameter is causing the error translation loaded too early in WordPress debug log

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

## Detailed scenario

### What was tested

Tested the new method with a translated string

### How to test

Navigate on a WP website with debug log enabled

## Technical description

### Documentation

This PR fixes an issue where translation strings were being loaded too early in WordPress, causing errors in the debug log. The fix removes the update message parameter from the Beta class constructor and instead initializes it with a default English value, adding a separate setter method for customization.

- Removed update message parameter from Beta class constructor
- Added default English update message and a setter method for customization

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
