### PR TITLE
Change the display of the beta update message

### DIFF
--- a/src/Beta.php
+++ b/src/Beta.php
@@ -253,7 +253,7 @@ class Beta {
 		}
 
 		printf(
-			'</p><p class="beta-update-notice">%s',
+			'&nbsp;<em>%s</em>',
 			esc_html( $this->update_message )
 		);
 	}


### PR DESCRIPTION
# Description

Display the beta update message in a way that doesn't cause it to duplicate the update notification

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

## Detailed scenario

### What was tested

- Tested on a website with the beta update available

### How to test

n/a

## Technical description

### Documentation

This PR fixes a bug where the beta update message was duplicating the update notification by changing its HTML display format. The change modifies how the beta update message is rendered to prevent duplication issues.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.